### PR TITLE
Don't skip reload on chmod if it's also write event

### DIFF
--- a/commands/serve.go
+++ b/commands/serve.go
@@ -99,10 +99,11 @@ func runWatcher(config *config.Config, broker *EventBroker) (*fsnotify.Watcher, 
 
 	go func() {
 		for event := range watcher.Events {
-			// chmod events are noisy, ignore them.
+			// chmod events are noisy, ignore them. But not if they are also a write event.
+			isChmod := event.Has(fsnotify.Chmod) && !event.Has(fsnotify.Write)
 			// Also ignore dot file events, which are usually spurious (e.g .DS_Store, emacs temp files)
 			isDotFile := strings.HasPrefix(filepath.Base(event.Name), ".")
-			if event.Has(fsnotify.Chmod) || isDotFile {
+			if isChmod || isDotFile {
 				continue
 			}
 


### PR DESCRIPTION
Fixes #36

I observed that some write events where being skipped, and noticed those where marked as `event WRITE|CHMOD` by fsnotify. As per [the doc](https://github.com/fsnotify/fsnotify/blob/cfc9c4f277ea6ec18de92444b31983b183deb4fb/fsnotify.go#L28-L31), multiple events can be sent at once.

This updates the code to only skip CHMOD when they are not also write events.