### PR TITLE
Build site using the pretty uris dir structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ To preview your site locally, use `jorge serve`:
 $ cd myblog
 $ jorge serve
 wrote target/feed.xml
-wrote target/blog/goodbye-markdown.html
-wrote target/blog/my-first-post.html
-wrote target/blog/hello-org.html
+wrote target/blog/goodbye-markdown/index.html
+wrote target/blog/my-first-post/index.html
+wrote target/blog/hello-org/index.html
 wrote target/blog/index.html
 wrote target/index.html
-wrote target/blog/tags.html
+wrote target/blog/tags/index.html
 serving at http://localhost:4001
 ```
 
@@ -96,10 +96,10 @@ Finally, you can render a minified version of your site with `jorge build`:
 $ jorge build
   wrote target/index.html
   wrote target/assets/css/main.css
-  wrote target/blog/hello.html
-  wrote target/blog/my-first-post.html
+  wrote target/blog/hello/index.html
+  wrote target/blog/my-first-post/index.html
   wrote target/feed.xml
-  wrote target/tags.html
+  wrote target/tags/index.html
 ```
 
 And that's about it. For more details see the:

--- a/commands/serve.go
+++ b/commands/serve.go
@@ -42,7 +42,7 @@ func (cmd *Serve) Run(ctx *kong.Context) error {
 	defer watcher.Close()
 
 	// serve the target dir with a file server
-	fs := http.FileServer(HTMLFileSystem{http.Dir(config.TargetDir)})
+	fs := http.FileServer(http.Dir(config.TargetDir))
 	http.Handle("/", fs)
 
 	if config.LiveReload {
@@ -154,24 +154,6 @@ func watchProjectFiles(watcher *fsnotify.Watcher, config *config.Config) error {
 		}
 		return nil
 	})
-}
-
-// Tweaks the http file system to construct a server that hides the .html suffix from requests.
-// Based on https://stackoverflow.com/a/57281956/993769
-type HTMLFileSystem struct {
-	dirFS http.Dir
-}
-
-func (htmlFS HTMLFileSystem) Open(name string) (http.File, error) {
-	// Try name as supplied
-	f, err := htmlFS.dirFS.Open(name)
-	if os.IsNotExist(err) {
-		// Not found, try with .html
-		if f, err := htmlFS.dirFS.Open(name + ".html"); err == nil {
-			return f, nil
-		}
-	}
-	return f, err
 }
 
 // The event broker mediates between the file watcher

--- a/docs/src/tutorial/3-jorge-serve.org
+++ b/docs/src/tutorial/3-jorge-serve.org
@@ -15,11 +15,11 @@ $ cd myblog
 $ jorge serve
 building site
 wrote target/feed.xml
-wrote target/blog/goodbye-markdown.html
-wrote target/blog/hello-org.html
+wrote target/blog/goodbye-markdown/index.html
+wrote target/blog/hello-org/index/.html
 wrote target/index.html
 wrote target/blog/index.html
-wrote target/blog/tags.html
+wrote target/blog/tags/index.html
 done
 serving at http://localhost:4001
 #+end_src

--- a/docs/src/tutorial/5-jorge-build.org
+++ b/docs/src/tutorial/5-jorge-build.org
@@ -13,12 +13,11 @@ So far you've seen how to [[file:jorge-init][start a project]], [[file:jorge-ser
 #+begin_src console
 $ jorge build
 skipping draft target/blog/my-own-blog-post.org
-wrote target/2024-02-23-another-kind-of-post.html
-wrote target/blog/my-own-blog-post.html
-wrote target/blog/goodbye-markdown.html
+wrote target/2024-02-23-another-kind-of-post/index.html
+wrote target/blog/goodbye-markdown/index.html
 wrote target/assets/css/main.css
-wrote target/blog/hello-org.html
-wrote target/blog/tags.html
+wrote target/blog/hello-org/index.html
+wrote target/blog/tags/index.html
 wrote target/index.html
 wrote target/feed.xml
 wrote target/blog/index.html
@@ -44,7 +43,7 @@ But for the sake of completeness, this is how this site is deployed: I have a VP
           location / {
               # First attempt to serve request as file,
               # then as directory. Otherwise respond 404.
-              try_files $uri $uri.html $uri/ =404;
+              try_files $uri $uri/ =404;
           }
   }
 

--- a/site/site.go
+++ b/site/site.go
@@ -330,9 +330,19 @@ func (site *site) buildFile(path string) error {
 		targetPath = strings.TrimSuffix(targetPath, filepath.Ext(targetPath)) + templ.TargetExt()
 		contentReader = bytes.NewReader(content)
 	}
+	targetExt := filepath.Ext(targetPath)
+
+	// arrange paths to ensure pretty uris, eg move blog/tags.html to blog/tags/index.html
+	if targetExt == ".html" && filepath.Base(targetPath) != "index.html" {
+		targetDir := strings.TrimSuffix(targetPath, ".html")
+		targetPath = filepath.Join(targetDir, "index.html")
+		err = os.MkdirAll(targetDir, DIR_RWE_MODE)
+		if err != nil {
+			return err
+		}
+	}
 
 	// post process file acording to extension and config
-	targetExt := filepath.Ext(targetPath)
 	contentReader, err = markup.Smartify(targetExt, contentReader)
 	if err != nil {
 		return err

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -511,9 +511,9 @@ layout: base
 	assertEqual(t, err, nil)
 
 	// test target files generated
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p1.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p1", "index.html"))
 	assertEqual(t, err, nil)
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p2.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p2", "index.html"))
 	assertEqual(t, err, nil)
 
 	// test index includes p1 and p2
@@ -580,9 +580,9 @@ layout: base
 	assertEqual(t, err, nil)
 
 	// test target files generated
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p1.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p1", "index.html"))
 	assertEqual(t, err, nil)
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p2.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p2", "index.html"))
 	assertEqual(t, err, nil)
 
 	// test index includes p1 and p2
@@ -605,9 +605,9 @@ layout: base
 	assertEqual(t, err, nil)
 
 	// test only non drafts generated
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p1.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p1", "index.html"))
 	assertEqual(t, err, nil)
-	_, err = os.Stat(filepath.Join(config.TargetDir, "p2.html"))
+	_, err = os.Stat(filepath.Join(config.TargetDir, "p2", "index.html"))
 	assert(t, os.IsNotExist(err))
 
 	// test index includes p1 but  NOT p2


### PR DESCRIPTION
This updates site generation logic to produce <filename>/index.html instead of <filename>.html files. This reduces the server support required to e.g. serve `src/blog/tags.html` at `/blog/tags`.

The PR updates the documentation and the local server accordingly.

Fixes #35