### PR TITLE
Enable markdown extensions

### DIFF
--- a/commands/initfiles/src/blog/goodbye-markdown.md
+++ b/commands/initfiles/src/blog/goodbye-markdown.md
@@ -10,8 +10,6 @@ layout: post
 For the record, even though it has *org* in the name, jorge can also render markdown,
 thanks to [goldmark](https://github.com/yuin/goldmark/).
 
-Would it support footnotes[^1]?
-
 Let's look at some code:
 
 ``` python
@@ -23,6 +21,14 @@ def hello():
 
 hello()
 ```
+
+Let's try some gfm extensions. This is ~~strikethrough~~.
+
+| foo | bar |
+| --- | --- |
+| baz | bim |
+
+Would it support footnotes[^1]?
 
 [Next time](./hello-org), I'll talk about org-mode posts.
 

--- a/commands/initfiles/src/blog/goodbye-markdown.md
+++ b/commands/initfiles/src/blog/goodbye-markdown.md
@@ -10,6 +10,8 @@ layout: post
 For the record, even though it has *org* in the name, jorge can also render markdown,
 thanks to [goldmark](https://github.com/yuin/goldmark/).
 
+Would it support footnotes[^1]?
+
 Let's look at some code:
 
 ``` python
@@ -23,3 +25,5 @@ hello()
 ```
 
 [Next time](./hello-org), I'll talk about org-mode posts.
+
+[^1]: apparently it would?

--- a/markup/templates.go
+++ b/markup/templates.go
@@ -18,6 +18,7 @@ import (
 	"github.com/osteele/liquid"
 	"github.com/yuin/goldmark"
 	gm_highlight "github.com/yuin/goldmark-highlighting/v2"
+	"github.com/yuin/goldmark/extension"
 	"gopkg.in/yaml.v3"
 )
 
@@ -169,10 +170,13 @@ func (templ Template) RenderWith(context map[string]interface{}, hlTheme string)
 
 		options := make([]goldmark.Option, 0)
 		if hlTheme != NO_SYNTAX_HIGHLIGHTING {
-			options = append(options, goldmark.WithExtensions(gm_highlight.NewHighlighting(
-				gm_highlight.WithStyle(hlTheme),
-				gm_highlight.WithFormatOptions(html.TabWidth(CODE_TABWIDTH)),
-			)))
+
+			options = append(options, goldmark.WithExtensions(
+				extension.Footnote,
+				gm_highlight.NewHighlighting(
+					gm_highlight.WithStyle(hlTheme),
+					gm_highlight.WithFormatOptions(html.TabWidth(CODE_TABWIDTH)),
+				)))
 		}
 		md := goldmark.New(options...)
 		if err := md.Convert(content, &buf); err != nil {

--- a/markup/templates.go
+++ b/markup/templates.go
@@ -172,6 +172,7 @@ func (templ Template) RenderWith(context map[string]interface{}, hlTheme string)
 		if hlTheme != NO_SYNTAX_HIGHLIGHTING {
 
 			options = append(options, goldmark.WithExtensions(
+				extension.GFM,
 				extension.Footnote,
 				gm_highlight.NewHighlighting(
 					gm_highlight.WithStyle(hlTheme),


### PR DESCRIPTION
This enables footnoes and github flavored markdown [goldmark extensions](https://github.com/yuin/goldmark?tab=readme-ov-file#built-in-extensions).

fixes #45