### PR TITLE
Expose list of static_files as template variables

### DIFF
--- a/site/site.go
+++ b/site/site.go
@@ -172,7 +172,7 @@ func (site *site) loadTemplates() error {
 			}
 			templ.Metadata["src_path"] = srcPath
 			templ.Metadata["path"] = targetPath
-			templ.Metadata["url"] = "/" + strings.TrimSuffix(strings.TrimSuffix(targetPath, "index.html"), ".html")
+			templ.Metadata["url"] = "/" + strings.TrimSuffix(strings.TrimSuffix(targetPath, "/index.html"), ".html")
 			templ.Metadata["dir"] = "/" + filepath.Dir(relPath)
 			templ.Metadata["slug"] = filepath.Base(templ.Metadata["url"].(string))
 

--- a/site/site.go
+++ b/site/site.go
@@ -156,6 +156,7 @@ func (site *site) loadTemplates() error {
 			templ.Metadata["path"] = relPath
 			templ.Metadata["url"] = "/" + strings.TrimSuffix(strings.TrimSuffix(relPath, "index.html"), ".html")
 			templ.Metadata["dir"] = "/" + filepath.Dir(relPath)
+			templ.Metadata["slug"] = filepath.Base(templ.Metadata["url"].(string))
 
 			// if drafts are disabled, exclude from posts, page and tags indexes, but not from site.templates
 			// we want to explicitly exclude the template from the target, rather than treating it as a non template file


### PR DESCRIPTION
Add site.static_files, that can be used similarly to site.posts and site.pages for files that are not templates. This is useful eg. to list images in an epub manifest. The metadata names were copied from the [jekyll equivalent](https://jekyllrb.com/docs/static-files/).

Also added a slug field to regular templates.

This area of the code may need future cleaning up and updates for naming clarity/consistency.