### PR TITLE
Add a jorge meta command to get site metadata in scripts

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -49,3 +49,25 @@ func Prompt(label string) string {
 	}
 	return strings.TrimSpace(s)
 }
+
+type Meta struct {
+	Expression string `arg:"" name:"expression" default:"site" help:"liquid expression to be evaluated (what goes inside of {{ ... }} in templates)"`
+}
+
+// Load the site metadata and use it as context to evaluate a liquid expression
+func (cmd *Meta) Run(ctx *kong.Context) error {
+
+	config, err := config.Load(".")
+	if err != nil {
+		return err
+	}
+
+	// remove optional {{}} wrapper
+	expression := strings.Trim(cmd.Expression, " {}")
+
+	result, err := site.EvalMetadata(*config, expression)
+	if err == nil {
+		fmt.Println(result)
+	}
+	return err
+}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ var cli struct {
 	Build   commands.Build   `cmd:"" help:"Build a website project." aliases:"b"`
 	Post    commands.Post    `cmd:"" help:"Initialize a new post template file." aliases:"p"`
 	Serve   commands.Serve   `cmd:"" help:"Run a local server for the website." aliases:"s"`
+	Meta    commands.Meta    `cmd:"" help:"Get the JSON results from evaluating a liquid template expression within the site context." aliases:"m"`
 	Version kong.VersionFlag `short:"v"`
 }
 

--- a/markup/templates.go
+++ b/markup/templates.go
@@ -42,6 +42,11 @@ func NewEngine(siteUrl string, includesDir string) *Engine {
 	return e
 }
 
+func EvalExpression(engine *Engine, expression string, context map[string]interface{}) (string, error) {
+	template := fmt.Sprintf("{{ %s | json }}", expression)
+	return engine.ParseAndRenderString(template, context)
+}
+
 // Try to parse a liquid template at the given location.
 // Files starting with front matter (--- sorrrounded yaml)
 // are considered templates. If the given file is not headed by front matter

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -303,7 +303,7 @@ date: 2023-01-01
 	assertEqual(t, err, nil)
 	assertEqual(t, output, `["goodbye!","hello world!","an oldie!"]`)
 
-	output, err = EvalMetadata(*config, "site.posts | map:'title")
+	_, err = EvalMetadata(*config, "site.posts | map:'title")
 	assert(t, strings.Contains(err.Error(), "Liquid error"))
 }
 

--- a/site/site_test.go
+++ b/site/site_test.go
@@ -271,6 +271,42 @@ date: 2023-01-01
 </ul>`)
 }
 
+func TestEvalMetadata(t *testing.T) {
+	config := newProject()
+	defer os.RemoveAll(config.RootDir)
+
+	content := `---
+title: hello world!
+date: 2024-01-01
+---
+<p>Hello world!</p>`
+	file := newFile(config.SrcDir, "hello.html", content)
+	defer os.Remove(file.Name())
+
+	content = `---
+title: goodbye!
+date: 2024-02-01
+---
+<p>goodbye world!</p>`
+	file = newFile(config.SrcDir, "goodbye.html", content)
+	defer os.Remove(file.Name())
+
+	content = `---
+title: an oldie!
+date: 2023-01-01
+---
+<p>oldie</p>`
+	file = newFile(config.SrcDir, "an-oldie.html", content)
+	defer os.Remove(file.Name())
+
+	output, err := EvalMetadata(*config, "site.posts | map:'title'")
+	assertEqual(t, err, nil)
+	assertEqual(t, output, `["goodbye!","hello world!","an oldie!"]`)
+
+	output, err = EvalMetadata(*config, "site.posts | map:'title")
+	assert(t, strings.Contains(err.Error(), "Liquid error"))
+}
+
 func TestRenderTags(t *testing.T) {
 	config := newProject()
 	defer os.RemoveAll(config.RootDir)


### PR DESCRIPTION
The command returns data in JSON format and accepts liquid template expressions for filtering, which can be handy for scripting and ad hoc processing of the project files.

Example:

``` shell
$ jorge meta 'site.posts | where:"lang","en"|where_exp:"post", "post.external == nil"|map:"title"' | jq -r '.[]' | head -5
Are We Living in a Simulation?
My Software Bookshelf
Software Possession for Personal Use
Deconstructing the Role-Playing Video Game
A Computing Magazine Anthology
```